### PR TITLE
Reinstall webpack to mitigate security issue with serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11756,9 +11756,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "serve-index": {
@@ -13000,9 +13000,9 @@
       }
     },
     "terser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.1.tgz",
-      "integrity": "sha512-e05giplw+8sIYh50qXYHZmr0b76O5dOSm9JwSDebGFLri4ItYzxsnumiAK+yuI56R+H7uIjT9KbVEKNkrprzHw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
+      "integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -13019,16 +13019,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.2.tgz",
+      "integrity": "sha512-fdEb91kR2l+BVgES77N/NTXWZlpX6vX+pYPjnX5grcDYBF2CMnzJiXX4NNlna4l04lvCW39lZ+O/jSvUhHH/ew==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.1",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "style-loader": "1.0.1",
     "ts-jest": "24.2.0",
     "typescript": "3.7.3",
-    "webpack": "^4.41.2",
+    "webpack": "4.41.2",
     "webpack-cli": "3.3.10",
     "webpack-dev-server": "3.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "style-loader": "1.0.1",
     "ts-jest": "24.2.0",
     "typescript": "3.7.3",
-    "webpack": "4.41.2",
+    "webpack": "^4.41.2",
     "webpack-cli": "3.3.10",
     "webpack-dev-server": "3.9.0"
   },


### PR DESCRIPTION
La til ^ for å oppdatere webpack dependencies til siste minor/patch versjon. 

Gjerne ta en vurdering her på om vi ønsker at ^ skal legges til. I utgangspunktet skal det ikke ha så mye å si, ettersom det i teorien ikke skal introdusere breaking changes. 